### PR TITLE
Add a simple REPL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ byteorder = "1.0.0"
 clap = "2.26.2"
 libc = "0.2.24"
 rand = "0.3"
+rustyline = "1.0.0"
 y4m = "0.1.1"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Input videos must be a multiple of 64 high and wide, in y4m format.
 # Compressing video
 
 ```
-cargo run --release input.y4m output.ivf
+cargo run --bin rav1e --release input.y4m output.ivf
 ```
 # Decompressing video
 

--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -1,0 +1,22 @@
+extern crate rav1e;
+extern crate y4m;
+
+use rav1e::*;
+
+fn main() {
+    let mut files = EncoderFiles::from_cli();
+    let mut y4m_dec = y4m::decode(&mut files.input_file).unwrap();
+    let width = y4m_dec.get_width();
+    let height = y4m_dec.get_height();
+    let mut y4m_enc = y4m::encode(width,height,y4m::Ratio::new(30,1)).write_header(&mut files.rec_file).unwrap();
+    let fi = FrameInvariants::new(width, height);
+    let sequence = Sequence::new();
+    write_ivf_header(&mut files.output_file, fi.sb_width*64, fi.sb_height*64);
+
+    let mut frame_number = 0;
+    loop {
+        process_frame(frame_number, &sequence, &fi,
+                      &mut files.output_file, &mut y4m_dec, &mut y4m_enc);
+        frame_number += 1;
+    }
+}

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -1,0 +1,45 @@
+extern crate rustyline;
+extern crate y4m;
+
+extern crate rav1e;
+use rav1e::*;
+
+use rustyline::error::ReadlineError;
+use rustyline::Editor;
+
+fn main() {
+    let mut files = EncoderFiles::from_cli();
+    let mut y4m_dec = y4m::decode(&mut files.input_file).unwrap();
+    let width = y4m_dec.get_width();
+    let height = y4m_dec.get_height();
+    let mut y4m_enc = y4m::encode(width,height,y4m::Ratio::new(30,1)).write_header(&mut files.rec_file).unwrap();
+    let fi = FrameInvariants::new(width, height);
+    let sequence = Sequence::new();
+    write_ivf_header(&mut files.output_file, fi.sb_width*64, fi.sb_height*64);
+
+    let mut frame_number = 0;
+    let mut rl = Editor::<()>::new();
+    let _ = rl.load_history(".rav1e-history");
+    loop {
+        let readline = rl.readline(">> ");
+        match readline {
+            Ok(line) => {
+                rl.add_history_entry(&line);
+                match line.split_whitespace().next() {
+                    Some("process_frame") => {
+                        process_frame(frame_number, &sequence, &fi,
+                                      &mut files.output_file, &mut y4m_dec, &mut y4m_enc);
+                        frame_number += 1;
+                    },
+                    Some(cmd) => {
+                        println!("Unrecognized command: {:?}", cmd);
+                    },
+                    None => {}
+                }
+            },
+            Err(ReadlineError::Eof) => break,
+            _ => {}
+        }
+    }
+    rl.save_history(".rav1e-history").unwrap();
+}


### PR DESCRIPTION
Currently only contains one command "process_repl" that encodes one frame.

To run the REPL:
```
cargo run --bin rav1repl
```
To run the main encoder (unfortunately there is no way to make "cargo run" do this by default):
```
cargo run --bin rav1e
```