### PR TITLE
Fix incorrect prediction introduced in 0df1e6ed.

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -106,7 +106,7 @@ use plane::*;
 use predict::*;
 
 fn setup_left(left: &mut [u16; 4], rec: &PlaneMutSlice) {
-    let left_slice = rec.go_left(1);
+    let left_slice = rec.go_up(1);
     for i in 0..4 {
         left[i] = left_slice.p(0, i);
     }
@@ -121,12 +121,12 @@ impl PredictionMode {
         let y = dst.y;
 
         if (self == &PredictionMode::V_PRED ||
-            self == &PredictionMode::DC_PRED) && x != 0 {
-            above.copy_from_slice(&dst.go_up(1).as_slice()[..4]);
+            self == &PredictionMode::DC_PRED) && y != 0 {
+            above.copy_from_slice(&dst.go_left(1).as_slice()[..4]);
         }
 
         if (self == &PredictionMode::H_PRED ||
-            self == &PredictionMode::DC_PRED) && y != 0 {
+            self == &PredictionMode::DC_PRED) && x != 0 {
             setup_left(&mut left, dst);
         }
 


### PR DESCRIPTION
The names go_left() and go_up() return the above and left slices
 respectivley which is confusing and why the previous patch did not
 predict properly.
This will be addressed in a separate patch.