### PR TITLE
Rationalize go_up() and go_left() functions.

### DIFF
--- a/src/partition.rs
+++ b/src/partition.rs
@@ -106,7 +106,7 @@ use plane::*;
 use predict::*;
 
 fn setup_left(left: &mut [u16; 4], rec: &PlaneMutSlice) {
-    let left_slice = rec.go_up(1);
+    let left_slice = rec.go_left(1);
     for i in 0..4 {
         left[i] = left_slice.p(0, i);
     }
@@ -122,7 +122,7 @@ impl PredictionMode {
 
         if (self == &PredictionMode::V_PRED ||
             self == &PredictionMode::DC_PRED) && y != 0 {
-            above.copy_from_slice(&dst.go_left(1).as_slice()[..4]);
+            above.copy_from_slice(&dst.go_up(1).as_slice()[..4]);
         }
 
         if (self == &PredictionMode::H_PRED ||

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -74,8 +74,8 @@ impl<'a> PlaneSlice<'a> {
     pub fn go_up(&'a self, i: usize) -> PlaneSlice<'a> {
         PlaneSlice {
             plane: self.plane,
-            x: self.x - i,
-            y: self.y,
+            x: self.x,
+            y: self.y - i,
         }
     }
 
@@ -83,8 +83,8 @@ impl<'a> PlaneSlice<'a> {
     pub fn go_left(&'a self, i: usize) -> PlaneSlice<'a> {
         PlaneSlice {
             plane: self.plane,
-            x: self.x,
-            y: self.y - i,
+            x: self.x - i,
+            y: self.y,
         }
     }
 
@@ -113,8 +113,8 @@ impl<'a> PlaneMutSlice<'a> {
     pub fn go_up(&'a self, i: usize) -> PlaneSlice<'a> {
         PlaneSlice {
             plane: self.plane,
-            x: self.x - i,
-            y: self.y,
+            x: self.x,
+            y: self.y - i,
         }
     }
 
@@ -122,8 +122,8 @@ impl<'a> PlaneMutSlice<'a> {
     pub fn go_left(&'a self, i: usize) -> PlaneSlice<'a> {
         PlaneSlice {
             plane: self.plane,
-            x: self.x,
-            y: self.y - i,
+            x: self.x - i,
+            y: self.y,
         }
     }
 


### PR DESCRIPTION
The functions go_up() and go_left() now correctly return the above and
 left slices.