### PR TITLE
Buffer last reconstructed frame

### DIFF
--- a/src/bin/rav1e.rs
+++ b/src/bin/rav1e.rs
@@ -16,8 +16,9 @@ fn main() {
     let sequence = Sequence::new();
     write_ivf_header(&mut files.output_file, fi.sb_width*64, fi.sb_height*64);
 
+    let mut last_rec: Option<Frame> = None;
     loop {
-        if !process_frame(&sequence, &fi, &mut files.output_file, &mut y4m_dec, y4m_enc.as_mut()) {
+        if !process_frame(&sequence, &fi, &mut files.output_file, &mut y4m_dec, y4m_enc.as_mut(), &mut last_rec) {
             break;
         }
         fi.number += 1;

--- a/src/bin/rav1repl.rs
+++ b/src/bin/rav1repl.rs
@@ -22,6 +22,7 @@ fn main() {
 
     let mut rl = Editor::<()>::new();
     let _ = rl.load_history(".rav1e-history");
+    let mut last_rec: Option<Frame> = None;
     loop {
         let readline = rl.readline(">> ");
         match readline {
@@ -29,7 +30,7 @@ fn main() {
                 rl.add_history_entry(&line);
                 match line.split_whitespace().next() {
                     Some("process_frame") => {
-                        process_frame(&sequence, &fi, &mut files.output_file, &mut y4m_dec, y4m_enc.as_mut());
+                        process_frame(&sequence, &fi, &mut files.output_file, &mut y4m_dec, y4m_enc.as_mut(), &mut last_rec);
                         fi.number += 1;
                         if fi.number == files.limit {
                             break;


### PR DESCRIPTION
The "Show Existing Frames" feature uses this to copy into the reconstruction stream.
This demonstrates the plumbing required to resolve #67, and only covers the current behavior.
For future-proofing, an actual frame context buffer is needed.