### PR TITLE
Increase the minimum quantizer for segment index range fallback

### DIFF
--- a/src/rdo.rs
+++ b/src/rdo.rs
@@ -633,7 +633,7 @@ fn luma_chroma_mode_rdo<T: Pixel>(
       if fi.base_q_idx as i16
         + ts.segmentation.data[heuristic_sidx as usize]
           [SegLvl::SEG_LVL_ALT_Q as usize]
-        < 1
+        < 2
       {
         0..=0
       } else {
@@ -641,7 +641,7 @@ fn luma_chroma_mode_rdo<T: Pixel>(
       }
     } else if fi.base_q_idx as i16
       + ts.segmentation.data[2][SegLvl::SEG_LVL_ALT_Q as usize]
-      < 1
+      < 2
     {
       0..=1
     } else {


### PR DESCRIPTION
Fixes bitstream corruption at low quantizers (xiph#1719).